### PR TITLE
feat: make polygonBbox available

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2192,6 +2192,22 @@ declare namespace cytoscape {
          */
         renderedBoundingBox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
         renderedBoundingbox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
+        /**
+         * Get the bounding polygon of the elements in model coordinates.
+         * Returns an array of points [{x, y}, ...] representing the polygon.
+         * 
+         * @returns Polygon in model coordinate space.
+         */
+        actualLabelBoundingBox(): PolygonBoundingBox;
+        actualLabelBoundingbox(): PolygonBoundingBox;
+        /**
+         * Get the bounding polygon of the elements in rendered coordinates.
+         * Returns an array of points [{x, y}, ...] representing the polygon.
+         * 
+         * @returns Polygon in rendered coordinate space.
+         */
+        renderedActualLabelBoundingBox(): PolygonBoundingBox;
+        renderedActualLabelBoundingbox(): PolygonBoundingBox;
     }
 
     /**
@@ -2996,6 +3012,30 @@ declare namespace cytoscape {
              */
             ele: SingularElementReturnValue;
         };
+        /**
+         * Returns a new collection containing nodes whose position lies inside
+         * the specified rectangular box in model coordinates.
+         * This is a spatial filter based on element positions.
+         *
+         * @param box BoundingBox12 & BoundingBoxWH
+         */
+        withinBox(box: BoundingBox12 & BoundingBoxWH): Collection<TIn>;
+        /**
+         * Returns a new collection containing nodes whose polygonal bounds
+         * intersect the specified polygon in model coordinates.
+         * This is a spatial filter based on polygon-polygon intersection using SAT.
+         *
+         * @param polygon Array of points {x, y} defining a polygon
+         */
+        polygonIntersection(polygon: PolygonBoundingBox): Collection<TIn>;
+        /**
+         * Returns a new collection containing nodes whose label polygon bounds
+         * contain the specified point (in model coordinates).
+         * This is useful for hit-testing clicks inside rendered labels.
+         *
+         * @param point The point in model coordinates {x, y}
+         */
+        labelsContainPoint(point: Position): Collection<TIn>;
     }
 
     /**
@@ -6225,6 +6265,7 @@ declare namespace cytoscape {
         w: number;
         h: number;
     }
+    type PolygonBoundingBox = Position[];
     interface AnimatedLayoutOptions {
         // whether to transition the node positions
         animate?: boolean;

--- a/src/collection/dimensions/bounds.mjs
+++ b/src/collection/dimensions/bounds.mjs
@@ -27,6 +27,53 @@ elesfn.renderedBoundingBox = function( options ){
   };
 };
 
+elesfn.renderedActualLabelBoundingBox = function(){
+  let polygon = this.actualLabelBoundingBox();
+  let cy = this.cy();
+  let zoom = cy.zoom();
+  let pan = cy.pan();
+
+  return polygon.map(p => ({
+    x: p.x * zoom + pan.x,
+    y: p.y * zoom + pan.y
+  }));
+};
+
+elesfn.actualLabelBoundingBox = function() {
+  let bounds;
+
+  let isDirty = memoize(ele => {
+    let _p = ele._private;
+
+    return _p.labelPolygonCache == null || _p.styleDirty || _p.labelPolygonPosKey !== getLabelPolygonPosKey(ele);
+  }, ele => ele.id());
+
+  if (this.length === 1 && !isDirty(this[0])) {
+    bounds = this[0]._private.labelPolygonCache;
+  } else {
+    let eles = this;
+    let cy = eles.cy();
+    let styleEnabled = cy.styleEnabled();
+    this.edges().forEach(isDirty);
+    this.nodes().forEach(isDirty);
+
+    if(styleEnabled) {
+      this.recalculateRenderedStyle();
+    }
+
+    for (let i = 0; i < eles.length; i++) {
+      let ele = eles[i];
+      let _p = ele._private;
+      let polygon = getRotatedLabelBox(ele);
+      _p.labelPolygonCache = polygon;
+      _p.labelPolygonPosKey = getLabelPolygonPosKey(ele);
+      bounds = polygon;
+    }
+  }
+
+  return bounds;
+};
+
 elesfn.dirtyCompoundBoundsCache = function(silent = false){
   let cy = this.cy();
 
@@ -223,6 +270,69 @@ let updateBoundsFromBox = function( b, b2 ){
 let prefixedProperty = function( obj, field, prefix ){
   return getPrefixedProperty( obj, field, prefix );
 };
+
+let getRotatedLabelBox = function (ele, prefix) {
+
+  if( ele.cy().headless() ){ return; }
+
+  var _p = ele._private;
+  let cy = ele.cy();
+  var zoom = cy.zoom();
+  var th = 2 / zoom;
+  ele.boundingBox({ includeLabels: true });
+
+  var prefixDash = prefix ? prefix + '-' : '';
+  let label = ele.pstyle( prefixDash + 'label' ).strValue;
+  if (!label) {
+    return null;
+  }
+  let bbPrefix = prefix || 'main';
+  let bbs = _p.labelBounds;
+  let bb = bbs[bbPrefix] = bbs[bbPrefix] || {};
+
+  // If the bounding box is not available, return null.
+  // This indicates that the label box cannot be calculated, which is consistent
+  // with the expected behavior of this function. Returning null allows the caller
+  // to handle the absence of a bounding box explicitly.
+  if (!bb) {
+    return null;
+  }
+
+  var lx = prefixedProperty(_p.rscratch, 'labelX', prefix);
+  var ly = prefixedProperty(_p.rscratch, 'labelY', prefix);
+  var theta = prefixedProperty(_p.rscratch, 'labelAngle', prefix);
+
+  var ox = ele.pstyle(prefixDash + 'text-margin-x').pfValue;
+  var oy = ele.pstyle(prefixDash + 'text-margin-y').pfValue;
+
+  var lx1 = bb.x1 - th - ox;
+  var lx2 = bb.x2 + th - ox;
+  var ly1 = bb.y1 - th - oy;
+  var ly2 = bb.y2 + th - oy;
+
+  if (theta) {
+    var cos = Math.cos(theta);
+    var sin = Math.sin(theta);
+
+    var rotate = function (x, y) {
+      x = x - lx;
+      y = y - ly;
+      return {
+        x: x * cos - y * sin + lx,
+        y: x * sin + y * cos + ly,
+      };
+    };
+
+    return [rotate(lx1, ly1), rotate(lx2, ly1), rotate(lx2, ly2), rotate(lx1, ly2)];
+  } else {
+    return [
+      { x: lx1, y: ly1 },
+      { x: lx2, y: ly1 },
+      { x: lx2, y: ly2 },
+      { x: lx1, y: ly2 },
+    ];
+  }
+}
 
 let updateBoundsFromArrow = function( bounds, ele, prefix ){
   if( ele.cy().headless() ){ return; }
@@ -879,6 +989,17 @@ let cachedBoundingBoxImpl = function( ele, opts ){
   return bb;
 };
 
+let getLabelPolygonPosKey = function(ele) {
+  let pos = ele.position();
+  let angle = ele.pstyle('text-rotation').pfValue || 0;
+
+  return hashIntsArray([
+    Math.round(pos.x),
+    Math.round(pos.y),
+    Math.round(angle * 1000) 
+  ]);
+};
+
 let defBbOpts = {
   includeNodes: true,
   includeEdges: true,
@@ -979,6 +1100,8 @@ elesfn.dirtyBoundingBoxCache = function(){
     _p.arrowBounds.target = null;
     _p.arrowBounds['mid-source'] = null;
     _p.arrowBounds['mid-target'] = null;
+    _p.labelPolygonCache = null;
+    _p.labelPolygonPosKey = null;
   }
 
   this.emitAndNotify('bounds');
@@ -1041,5 +1164,7 @@ elesfn.boundingBoxAt = function( fn ){
 
 fn.boundingbox = fn.bb = fn.boundingBox;
 fn.renderedBoundingbox = fn.renderedBoundingBox;
+fn.actualLabelBoundingbox = fn.actualLabelBoundingBox;
+fn.renderedActualLabelBoundingbox = fn.renderedActualLabelBoundingBox;
 
 export default elesfn;

--- a/src/collection/filter.mjs
+++ b/src/collection/filter.mjs
@@ -1,5 +1,6 @@
 import * as is from '../is.mjs';
 import Selector from '../selector/index.mjs';
+import { satPolygonIntersection, pointInsidePolygon, pointInsidePolygonPoints } from '../math.mjs';
 
 let elesfn = ({
   nodes: function( selector ){
@@ -378,7 +379,65 @@ let elesfn = ({
       value: min,
       ele: minEle
     };
-  }
+  },
+
+  withinBox: function(box) {
+    let eles = this;
+    const { x1, y1, x2, y2 } = box;
+    let filtered = [];
+
+    for (let i = 0, len = eles.length; i < len; i++) {
+      const ele = eles[i];
+      const pos = ele._private.position || ele.position(); 
+      if (pos.x >= x1 && pos.x <= x2 && pos.y >= y1 && pos.y <= y2) {
+        filtered.push(ele);
+      }
+    }
+
+    return this.spawn(filtered);
+  },
+
+  labelsContainPoint: function(point) {
+    const nodes = this.nodes();
+    if (nodes.empty()) return this.spawn();
+
+    const inside = [];
+
+    for (let i = 0; i < nodes.length; i++) {
+      const ele = nodes[i];
+      const labelPoly = ele.actualLabelBoundingBox();
+
+      if (!labelPoly || labelPoly.length === 0) continue;
+
+      const flatPoints = [];
+      for (let j = 0; j < labelPoly.length; j++) {
+        flatPoints.push(labelPoly[j].x, labelPoly[j].y);
+      }
+
+      if (pointInsidePolygonPoints(point.x, point.y, flatPoints)) {
+        inside.push(ele);
+      }
+    }
+
+    return this.spawn(inside);
+  },
+
+  polygonIntersection: function(polygon) {
+    const matches = [];
+
+    for (let i = 0; i < this.length; i++) {
+      const ele = this[i];
+
+      const elePoly = ele.actualLabelBoundingBox();
+      if (!elePoly || !elePoly.length) continue;
+
+      if (satPolygonIntersection(elePoly, polygon)) {
+        matches.push(ele);
+      }
+    }
+
+    return this.spawn(matches);
+  },
 });
 
 // aliases


### PR DESCRIPTION
New Collection Methods to the Cytoscape.js collection API, enhancing support for label-based interactions and polygonal geometry operations. Key additions include:

- `withinBox(box: BoundingBox12 & BoundingBoxWH)`
Filters elements whose positions fall within a specified rectangular bounding box.
- `polygonIntersection(polygon: PolygonBoundingBox)`
Returns elements whose label polygons intersect with a given polygon using the Separating Axis Theorem (SAT).
- `labelsContainPoint(point: Position)`
Returns nodes whose label polygon contains a given point. Useful for hit-testing clicks inside rendered labels.

**Checklist**

Author:

- [ ] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
